### PR TITLE
Fix Discord not logging out if server crashes during startup

### DIFF
--- a/chatter-discord/src/main/java/me/axieum/mcmod/chatter/api/event/discord/ServerShutdownCallback.java
+++ b/chatter-discord/src/main/java/me/axieum/mcmod/chatter/api/event/discord/ServerShutdownCallback.java
@@ -1,0 +1,27 @@
+package me.axieum.mcmod.chatter.api.event.discord;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.crash.CrashReport;
+import org.jetbrains.annotations.Nullable;
+
+public interface ServerShutdownCallback
+{
+    /**
+     * Called when the server exits, be it gracefully or not.
+     */
+    Event<ServerShutdownCallback> EVENT =
+            EventFactory.createArrayBacked(ServerShutdownCallback.class, callbacks -> (server, crashReport) -> {
+                for (ServerShutdownCallback callback : callbacks)
+                    callback.onServerShutdown(server, crashReport);
+            });
+
+    /**
+     * Called when the server exits, be it gracefully or not.
+     *
+     * @param server      Minecraft server instance
+     * @param crashReport a crash report if the server crashed
+     */
+    void onServerShutdown(MinecraftServer server, @Nullable CrashReport crashReport);
+}

--- a/chatter-discord/src/main/java/me/axieum/mcmod/chatter/impl/discord/ChatterDiscord.java
+++ b/chatter-discord/src/main/java/me/axieum/mcmod/chatter/impl/discord/ChatterDiscord.java
@@ -4,6 +4,7 @@ import com.jagrosh.jdautilities.command.CommandClient;
 import me.axieum.mcmod.chatter.api.event.chat.ChatEvents;
 import me.axieum.mcmod.chatter.api.event.discord.JDAEvents;
 import me.axieum.mcmod.chatter.api.event.discord.MinecraftCommandEvents;
+import me.axieum.mcmod.chatter.api.event.discord.ServerShutdownCallback;
 import me.axieum.mcmod.chatter.api.event.player.PlayerEvents;
 import me.axieum.mcmod.chatter.api.event.world.EntityDeathMessageCallback;
 import me.axieum.mcmod.chatter.impl.discord.callback.discord.*;
@@ -86,7 +87,7 @@ public class ChatterDiscord implements DedicatedServerModInitializer, PreLaunchE
         ServerLifecycleEvents.SERVER_STARTING.register(new ServerLifecycleCallback());
         ServerLifecycleEvents.SERVER_STARTED.register(new ServerLifecycleCallback());
         ServerLifecycleEvents.SERVER_STOPPING.register(new ServerLifecycleCallback());
-        ServerLifecycleEvents.SERVER_STOPPED.register(new ServerLifecycleCallback());
+        ServerShutdownCallback.EVENT.register(new ServerLifecycleCallback());
         // Register player callbacks
         ServerPlayConnectionEvents.JOIN.register(new PlayerConnectionCallback());
         ServerPlayConnectionEvents.DISCONNECT.register(new PlayerConnectionCallback());

--- a/chatter-discord/src/main/java/me/axieum/mcmod/chatter/impl/discord/callback/minecraft/ServerLifecycleCallback.java
+++ b/chatter-discord/src/main/java/me/axieum/mcmod/chatter/impl/discord/callback/minecraft/ServerLifecycleCallback.java
@@ -1,15 +1,16 @@
 package me.axieum.mcmod.chatter.impl.discord.callback.minecraft;
 
+import me.axieum.mcmod.chatter.api.event.discord.ServerShutdownCallback;
 import me.axieum.mcmod.chatter.impl.discord.ChatterDiscord;
 import me.axieum.mcmod.chatter.impl.discord.util.DiscordDispatcher;
 import me.axieum.mcmod.chatter.impl.discord.util.ServerUtils;
 import me.axieum.mcmod.chatter.impl.util.MessageFormat;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.ServerStarted;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.ServerStarting;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.ServerStopped;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.ServerStopping;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.crash.CrashReport;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.io.File;
@@ -21,7 +22,7 @@ import java.util.Optional;
 import static me.axieum.mcmod.chatter.impl.discord.ChatterDiscord.LOGGER;
 import static me.axieum.mcmod.chatter.impl.discord.ChatterDiscord.getConfig;
 
-public class ServerLifecycleCallback implements ServerStarting, ServerStarted, ServerStopping, ServerStopped
+public class ServerLifecycleCallback implements ServerStarting, ServerStarted, ServerStopping, ServerShutdownCallback
 {
     // Prepare a reusable message formatter for all server lifecycle events
     private static final MessageFormat FORMATTER = new MessageFormat()
@@ -32,7 +33,7 @@ public class ServerLifecycleCallback implements ServerStarting, ServerStarted, S
     public void onServerStarting(MinecraftServer server)
     {
         // Capture a reference to the server instance
-        ServerUtils.INSTANCE = server;
+        ServerUtils.instance = server;
         // Send Discord notifications
         ChatterDiscord.getClient().ifPresent(jda -> {
             // Update the Discord bot status
@@ -71,24 +72,23 @@ public class ServerLifecycleCallback implements ServerStarting, ServerStarted, S
     }
 
     @Override
-    public void onServerStopped(MinecraftServer server)
+    public void onServerShutdown(MinecraftServer server, @Nullable CrashReport crashReport)
     {
         // Send Discord notifications
         ChatterDiscord.getClient().ifPresent(jda -> {
             // Update the Discord bot status
             jda.getPresence().setStatus(getConfig().bot.status.stopped);
             // Determine whether the server stopped unexpectedly
-            // NB: Update to Java 9's `Optional#ifPresentOrElse` when Java 8 support is dropped
-            if (!ServerUtils.getCrashReport().isPresent()) {
+            if (crashReport == null) {
                 // Dispatch a normal shutdown message to all configured channels
                 DiscordDispatcher.embed((embed, entry) -> embed.setColor(Color.RED)
                                                                .setDescription(FORMATTER.apply(entry.discord.stopped)),
                         (entry) -> entry.discord.stopped != null);
             } else {
                 // Fetch the crash report file
-                final Optional<File> file = ServerUtils.getCrashReportFile();
+                final Optional<File> file = ServerUtils.getCrashReportFile(crashReport);
                 // Add any additional message formats
-                FORMATTER.tokenize("reason", ServerUtils.getCrashReport().map(CrashReport::getMessage).orElse(""));
+                FORMATTER.tokenize("reason", crashReport.getMessage());
                 // Dispatch an unexpected shutdown message to all configured channels
                 DiscordDispatcher.embed((embed, entry) -> embed.setColor(Color.RED)
                                                                .setDescription(FORMATTER.apply(entry.discord.crashed)),

--- a/chatter-discord/src/main/java/me/axieum/mcmod/chatter/impl/discord/util/ServerUtils.java
+++ b/chatter-discord/src/main/java/me/axieum/mcmod/chatter/impl/discord/util/ServerUtils.java
@@ -12,9 +12,7 @@ import java.util.stream.LongStream;
 public final class ServerUtils
 {
     // Captured Minecraft server instance
-    public static @Nullable MinecraftServer INSTANCE = null;
-    // Captured Minecraft server crash report
-    public static @Nullable CrashReport CRASH_REPORT = null;
+    public static @Nullable MinecraftServer instance = null;
 
     /**
      * Returns the captured Minecraft server instance.
@@ -23,7 +21,7 @@ public final class ServerUtils
      */
     public static Optional<MinecraftServer> getInstance()
     {
-        return Optional.ofNullable(INSTANCE);
+        return Optional.ofNullable(instance);
     }
 
     /**
@@ -61,26 +59,18 @@ public final class ServerUtils
     }
 
     /**
-     * Returns the captured Minecraft server crash report.
+     * Returns the file for a given server crash report.
      *
-     * @return latest Minecraft server crash report if captured
+     * @param report a server crash report
+     * @return server crash report file if valid
      */
-    public static Optional<CrashReport> getCrashReport()
-    {
-        return Optional.ofNullable(CRASH_REPORT);
-    }
-
-    /**
-     * Returns the captured Minecraft server crash report file.
-     *
-     * @return latest Minecraft server crash report file if captured and valid
-     */
-    public static Optional<File> getCrashReportFile()
+    public static Optional<File> getCrashReportFile(@Nullable CrashReport report)
     {
         try {
-            return getCrashReport().map(CrashReportAccessor.class::cast)
-                                   .map(CrashReportAccessor::getFile)
-                                   .filter(File::exists);
+            return Optional.ofNullable(report)
+                           .map(CrashReportAccessor.class::cast)
+                           .map(CrashReportAccessor::getFile)
+                           .filter(File::exists);
         } catch (Exception e) {
             return Optional.empty();
         }


### PR DESCRIPTION
If the server crashes while starting, the stopped event is never triggered, and hence the bot is not told to stop.

Closes #27 